### PR TITLE
Fix: Resolve Nix build error by simplifying nixPkgs list

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -4,7 +4,7 @@ NODE_ENV = "production"
 VITE_APP_ENV = "production"
 
 [phases.setup]
-nixPkgs = ["nodejs_18", "nodejs_18.npm", "vite"]
+nixPkgs = ["nodejs_18"]
 
 [phases.install]
 cmds = [


### PR DESCRIPTION
This PR resolves the Nix build error by simplifying the nixPkgs list in nixpacks.toml. This avoids issues with Nix not correctly resolving attributes for npm and vite.