### PR TITLE
Fix: Resolve Nix build error by using pkgs. prefix for nixPkgs

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -4,7 +4,7 @@ NODE_ENV = "production"
 VITE_APP_ENV = "production"
 
 [phases.setup]
-nixPkgs = ["nodejs_18"]
+nixPkgs = ["pkgs.nodejs_18", "pkgs.nodejs_18.npm", "pkgs.vite"]
 
 [phases.install]
 cmds = [


### PR DESCRIPTION
This PR resolves the Nix build error by using the pkgs. prefix for nixPkgs in nixpacks.toml. This ensures that Nix correctly resolves the attributes for nodejs, npm, and vite.